### PR TITLE
add an id to the list item, so someone can link to it via an anchor hash

### DIFF
--- a/source/localizable/index.html.erb
+++ b/source/localizable/index.html.erb
@@ -19,7 +19,7 @@
   <p class="supporters--sub-title"><%= t('supporters.sub-title') %></p>
   <ul class="supporters--list">
     <% (data.supporters.usergroups + data.supporters.conferences).each do |supporter| %>
-      <li class="supporters--item">
+      <li id="supporters--<%= supporter.name.downcase.gsub(/\W/, '_') %>" class="supporters--item">
         <h3 class="supporters--item-name"><%= supporter.name %></h3>
         <div class="user group">
           <span class="supporters--item-location"><%= supporter.city %>/<%= supporter.country %></span>


### PR DESCRIPTION
i would like to put a link to our supporter section, but it's not possible right now as there are no anchorable tags.