### PR TITLE
Add Cologne.js to the list of supporters

### DIFF
--- a/data/supporters.json
+++ b/data/supporters.json
@@ -362,6 +362,31 @@
           "twitter": "sableRaph"
         }
       ]
+    },
+    {
+      "name": "Cologne.js",
+      "city": "Cologne",
+      "country": "Germany",
+      "link": "http://colognejs.de/",
+      "twitter": "cgnjs",
+      "contacts": [
+        {
+          "name": "Michael Hackstein",
+          "twitter": "mchacki"
+        },
+        {
+          "name": "Sebastian Tilch",
+          "twitter": "sebtilch"
+        },
+        {
+          "name": "Yunus Uyargil",
+          "twitter": "YunusUyargil"
+        },
+        {
+          "name": "Frederic Hemberger",
+          "twitter": "fhemberger"
+        }
+      ]
     }
   ],
   "conferences": [


### PR DESCRIPTION
Our Cologne.js meet-up wants to adopt this great CoC as well, so here we are.
I wasn't sure if everybody was fine with having their e-mail address listed (spam, etc.), so I went with the Twitter handles as a mean to contact first. (Every organizer can now choose to amend a PR with their favored contact addresses.) 

Unfortunately, the Twitter links weren't shown for contacts so far, I added them in #50.