### PR TITLE
Fixed links in German translations

### DIFF
--- a/locales/de.yml
+++ b/locales/de.yml
@@ -6,7 +6,7 @@ de:
   supporters:
     title: "Unterstützer"
     sub-title: "Diese Usergruppen und Konferenzen unterstützen den Berlin Code of Conduct:"
-    add: "Um deine Usergruppe/Konferenz hier aufzulisten, füge sie einfach in einem Pull Request an %{link:our repository} hinzu."
+    add: "Um deine Usergruppe/Konferenz hier aufzulisten, füge sie einfach in einem Pull Request an %{link:unser Repository} hinzu."
   footer:
-    attribution: "Dieser Verhaltenskodex ist vom %{link:pdx.rb code of conduct} abgeleitet."
+    attribution: "Dieser Verhaltenskodex ist vom %{link:PDX.rb Code of Conduct} abgeleitet."
 


### PR DESCRIPTION
Used slightly more German wording and German capitalisation.