### PR TITLE
Added macoun.de to the list of conferences

### DIFF
--- a/data/supporters.json
+++ b/data/supporters.json
@@ -776,6 +776,25 @@
           "email": "robin@coding-robin.de"
         }
       ]
+    },
+    {
+      "name": "Macoun - Mac OS X and iOS Developer Conference",
+      "city": "Frankfurt",
+      "country": "Germany",
+      "link": "https://macoun.de",
+      "twitter": "MacounFFM",
+      "contacts": [
+        {
+          "name": "Christian Hauser",
+          "phone": "+49 69 981 912 06",
+          "email": "contact@macoun.de"
+        },
+        {
+          "name": "Thomas Biedorf",
+          "phone": "+49 69 981 912 06",
+          "email": "contact@macoun.de"
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
Hi! I added Macoun, a OSX and iOS conference in Frankfurt, to the list. Thanks for providing us with this great CoC! :) 