### PR TITLE
Update WRUG phone number

### DIFF
--- a/data/supporters.json
+++ b/data/supporters.json
@@ -289,7 +289,7 @@
       "contacts": [
         {
           "name": "Piotr Szotkowski",
-          "phone": "+48 533 950 455",
+          "phone": "+48 501 28 30 20",
           "email": "chastell@chastell.net"
         },
         {


### PR DESCRIPTION
Warsaw Ruby Users Group phone number update. (I’ll keep the old one working until this is merged and deployed, of course.)