### PR TITLE
Add partial :: Conf as a supporter

### DIFF
--- a/data/supporters.json
+++ b/data/supporters.json
@@ -1078,6 +1078,35 @@
           "email": "opengnsys@gmail.com"
         }
       ]
+    },
+    {
+      "name": "partial :: Conf",
+      "city": "Sofia",
+      "country": "Bulgaria",
+      "link": "http://partialconf.com",
+      "twitter": "partialconf",
+      "contacts": [
+        {
+          "name": "Genadi Samokovarov",
+          "twitter": "gsamokovarov",
+          "email": "gsamokovarov@gmail.com"
+        },
+        {
+          "name": "Svetlozar Mihailov",
+          "twitter": "svetliomihailov",
+          "email": "svetliomihailov@gmail.com"
+        },
+        {
+          "name": "Svetlozar Todorov",
+          "twitter": "svetlozaurus",
+          "email": "svetlik@gmail.com"
+        },
+        {
+          "name": "Vestimir Markov",
+          "twitter": "vestimir",
+          "email": "me@vestimir.com"
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
I'm one of the EuRuKo 2016 organizers. We're planning a new conference, called [`partial :: Conf`](http://partialconf.com) which we're pretty close to announcing. We used the Berlin Code of Conduct for EuRuKo and we'll try to use it for Partial as well.