### PR TITLE
Add Hardware Hack Lab support

### DIFF
--- a/data/supporters.json
+++ b/data/supporters.json
@@ -1158,6 +1158,20 @@
           "twitter": "sql_aus_hh"
         }
       ]
+    },
+    {
+      "name": "Hardware Hack Lab",
+      "city": "New York",
+      "country": "United States of America",
+      "link": "https://hardwarehacklab.io/",
+      "twitter": "hardwarehacklab",
+      "contacts": [
+        {
+          "name": "Julien Deswaef",
+          "twitter": "xuv",
+          "email": "julien.deswaef@thoughworks.com"
+        }
+      ]
     }
   ]
 }

--- a/data/supporters.json
+++ b/data/supporters.json
@@ -1169,7 +1169,23 @@
         {
           "name": "Julien Deswaef",
           "twitter": "xuv",
-          "email": "julien.deswaef@thoughworks.com"
+          "email": "julien.deswaef@thoughtworks.com",
+          "phone":   "+1 646 427 4897"
+        },
+        {
+          "name": "Greg Dutcher",
+          "twitter": "greg_dutcher",
+          "email": "gdutcher@thoughtworks.com"
+        },
+        {
+          "name": "Andrew McWilliams",
+          "twitter": "jahyadotnet",
+          "email": "andy@hardwarehacklab.io"
+        },
+        {
+          "name": "Kent Rahman",
+          "email": "krahman@thoughtworks.com",
+          "phone":   "+1 917 734 7635"
         }
       ]
     }


### PR DESCRIPTION
Hello 

The Hardware Hack Lab is a weekly gathering and a free space for artists, hackers & innovators in NYC. We are proud to make the Berlin CoC as our Code of Conduct.

Thanks.

Julien