### PR TITLE
Remove "in public spaces"

### DIFF
--- a/source/localizable/_code-of-conduct.en.md
+++ b/source/localizable/_code-of-conduct.en.md
@@ -33,7 +33,7 @@ Unacceptable Behavior
 
 Unacceptable behaviors include: intimidating, harassing, abusive, discriminatory, derogatory or demeaning speech or actions by any participant in our community online, at all related events and in one-on-one communications carried out in the context of community business. Community event venues may be shared with members of the public; please be respectful to all patrons of these locations.
 
-Harassment includes: harmful or prejudicial verbal or written comments related to gender, sexual orientation, race, religion, disability; inappropriate use of nudity and/or sexual images in public spaces (including presentation slides); inappropriate depictions of violence in public spaces (including presentation slides); deliberate intimidation, stalking or following; harassing photography or recording; sustained disruption of talks or other events; inappropriate physical contact, and unwelcome sexual attention.
+Harassment includes: harmful or prejudicial verbal or written comments related to gender, sexual orientation, race, religion, disability; inappropriate use of nudity and/or sexual images (including presentation slides); inappropriate depictions of violence (including presentation slides); deliberate intimidation, stalking or following; harassing photography or recording; sustained disruption of talks or other events; inappropriate physical contact, and unwelcome sexual attention.
 
 
 Consequences of Unacceptable Behavior


### PR DESCRIPTION
This PR removes "in public spaces" from the clauses referring to "display of violent imagery" and "display of nudity".

The wording introduced confusion: what parts of the events are "public spaces" and what is the "private space" at an event? It also didn't add much to the intention of the clauses.