### PR TITLE
Remove "expected behaviour" paragraph

### DIFF
--- a/source/localizable/_code-of-conduct.de.md
+++ b/source/localizable/_code-of-conduct.de.md
@@ -18,20 +18,6 @@ Communities spiegeln die Gesellschaften wider, in denen sie existieren. Positive
 Wenn du Personen begegnest, die sich viel Mühe geben, unsere Community einladend und freundlich zu gestalten und alle Teilnehmenden dazu anregt, sich voll einzubringen, würden wir gerne davon hören.
 
 
-Erwartetes Verhalten
---------------------
-
-* Beteilige dich authentisch und aktiv. Dadurch trägst du zur Gesundheit und Langlebigkeit dieser Community bei.
-
-* Verhalte dich rücksichts- und respektvoll in Wort und Tat.
-
-* Bemühe dich um Zusammenarbeit, damit du Konflikte von Anfang an vermeiden kannst.
-
-* Nimm Abstand von erniedrigender, diskriminierender oder belästigender Sprache und Verhalten.
-
-* Achte auf deine Umgebung und die anderen Teilnehmenden. Mache die Veranstaltenden oder andere Anwesende darauf aufmerksam, wenn du eine gefährliche Situation, jemanden in Bedrängnis oder Verletzungen dieses Verhaltenskodexes bemerkst, selbst wenn sie zunächst belanglos erscheinen.
-
-
 Inakzeptables Verhalten
 -----------------------
 

--- a/source/localizable/_code-of-conduct.en.md
+++ b/source/localizable/_code-of-conduct.en.md
@@ -17,17 +17,6 @@ Communities mirror the societies in which they exist and positive action is esse
 
 If you see someone who is making an extra effort to ensure our community is welcoming, friendly, and encourages all participants to contribute to the fullest extent, we want to know.
 
-
-Expected Behavior
------------------
-
-*	Participate in an authentic and active way. In doing so, you contribute to the health and longevity of this community.
-*	Exercise consideration and respect in your speech and actions.
-*	Attempt collaboration before conflict.
-*	Refrain from demeaning, discriminatory, or harassing behavior and speech.
-*	Be mindful of your surroundings and of your fellow participants. Alert community leaders if you notice a dangerous situation, someone in distress, or violations of this Code of Conduct, even if they seem inconsequential.
-
-
 Unacceptable Behavior
 ---------------------
 

--- a/source/localizable/_code-of-conduct.es.md
+++ b/source/localizable/_code-of-conduct.es.md
@@ -18,17 +18,6 @@ Las comunidades son espejo de las sociedades en las cuales existen y las accione
 Si Ud. ve a alguien haciendo un esfuerzo extra por asegurarse que nuestra comunidad es acogedora, amistosa e incentiva a todos los que participan en ella a contribuir de manera completa, nos gustaría saberlo.
 
 
-Comportamiento esperado
------------------------
-
-*   Participe de un modo auténtico y activo. Al hacerlo contribuye a la salud y longevidad de esta comunidad.
-*   Ejercite la consideración y el respeto en su discurso y en sus acciones.
-*   Intente colaborar para evitar conflictos.
-*   Absténgase de discursos o comportamientos despectivos, discriminatorios o abusivos.
-*   Sea consciente de su entorno y de los/as otros/as participantes. Alerte a los líderes de la comunidad si nota alguna situación peligrosa, alguien sufriendo una situación comprometedora o violaciones de este Código de Conducta, incluso si parecieran poco importantes.
-
-
-
 Comportamiento inaceptable
 --------------------------
 

--- a/source/localizable/_code-of-conduct.fr.md
+++ b/source/localizable/_code-of-conduct.fr.md
@@ -18,16 +18,6 @@ Les communautés reflètent les sociétés dans lesquelles elle existent. Les ac
 Si vous observez quelqu'un qui prend un soin particulier à s'assurer que notre communauté est accueillante, amicale et encourageante pour tous ses participants, faites le nous savoir.
 
 
-Comportement attendu
------------------
-
-* Participez activement et avec authenticité. Ce faisant, vous contribuerez à rendre la communauté saine et durable.
-* Faites preuve de considération et de respect dans vos paroles et actes.
-* Préférez la coopération au conflit.
-* Ne pratiquez pas le harcèlement, la méchanceté et la discrimination dans votre comportement et dans vos paroles.
-* Soyez attentif à votre environnement et aux autres participants. Alertez les organisateurs si vous êtes témoin d'une situation dangereuse, d'une personne en situation de détresse ou d'une violation de ce code de conduite, même si cela vous semble sans conséquence.
-
-
 Comportements inacceptables
 ---------------------
 

--- a/source/localizable/_code-of-conduct.it.md
+++ b/source/localizable/_code-of-conduct.it.md
@@ -19,16 +19,6 @@ Le comunità sono lo specchio delle società nelle quali esse esistono ed agire 
 Se vieni a conoscenza di qualcuno/a che in maniera esemplare si assicura che la nostra comunità sia accogliente, amichevole e che attivamente incoraggia tutti/e i/le partecipanti nel contribuire al massimo, faccelo sapere!
 
 
-Il comportamento che ci aspettiamo
------------------
-
-* Partecipa in maniera autentica e attiva. Così facendo, dai il tuo contributo per una comunità sana e longeva.
-* Sii attento e rispettoso riguardo a cosa dici e a come agisci.
-* Cerca di collaborare prima di entrare in conflitto.
-* Astieniti da commenti, discussioni o comportamenti avvilenti, discriminatori o molesti.
-* Sii conscio/a dell'ambiente e dei/delle suoi/sue partecipanti. Se noti una situazione pericolosa, qualcuno che non si sente a suo agio o una violazione di questo Codice di Condotta, avvisa immediatamente i leaders della comunità, anche se la situazione non sembra poter avere conseguenze particolarmente dannose.
-
-
 Comportamento inaccettabile
 ---------------------
 

--- a/source/localizable/_code-of-conduct.pl.md
+++ b/source/localizable/_code-of-conduct.pl.md
@@ -18,16 +18,6 @@ Społeczności odzwierciedlają społeczeństwa w ramach których istnieją, dla
 Jeśli widzisz kogoś wkładającego dodatkowy wysiłek by zapewnić, że nasza społeczność jest przyjazna, życzliwa i zachęcająca wszystkich uczestników do wnoszenia w nią jak największego wkładu – chcielibyśmy o tym wiedzieć.
 
 
-Zachowania oczekiwane
----------------------
-
-*	Uczestnicz w sposób autentyczny i aktywny. Robiąc to przyczyniasz się do zdrowia i żywotności tej społeczności.
-*	Zachowuj rozwagę i szacunek w swoich słowach i czynach.
-*	Spróbuj współpracy przed konfliktem.
-*	Powstrzymuj się przed poniżającymi, dyskryminującymi lub niepokojącymi zachowaniami i słowami.
-*	Zwracaj uwagę na swoje otoczenie i innych uczestników. Ostrzeż społeczność jeśli zauważysz niebezpieczną sytuację, kogoś potrzebującego pomocy lub naruszenie tego Kodeksu postępowania, nawet jeśli wydają się nieistotne.
-
-
 Zachowania niedopuszczalne
 --------------------------
 


### PR DESCRIPTION
This PR removes the entire "expected behaviour" paragraph. The reason is that all points are problematic or redundant.

In detail:

>     Participate in an authentic and active way. In doing so, you contribute to the health and longevity of this community.

"authentic" not defined and often used to accuse people with behavior not falling within certain social norms.

"active" is opposed to "passive" and passive participation in a community is perfectly fine.

>     Exercise consideration and respect in your speech and actions.

The intention here is clear, but there is no conclusion to be had from this.

>     Attempt collaboration before conflict.

This phrase can be used to accuse people reporting issues of not reporting in "the right way".

>     Refrain from demeaning, discriminatory, or harassing behavior and speech.

This is completely covered in detail in the following paragraph.

>     Be mindful of your surroundings and of your fellow participants. Alert community leaders if you notice a dangerous situation, someone in distress, or violations of this Code of Conduct, even if they seem inconsequential.

This is completely covered in its own paragraph.

Some of the intention in these bullet points can be better weaved into either the "purpose" section, the suggested preamble or the relevant other sections.
