### PR TITLE
Add creative commons sharealike 4.0 International version in EN and DE

### DIFF
--- a/source/localizable/_code-of-conduct.de.md
+++ b/source/localizable/_code-of-conduct.de.md
@@ -70,4 +70,4 @@ Wir erwarten, dass sich alle Teilnehmenden der Community (bezahlte oder unbezahl
 Lizenz und Namensnennung
 ------------------------
 
-Der Berlin Code of Conduct steht unter der Creative Commons Attribution-ShareAlike Lizenz. Er basiert auf dem [pdx.rb code of conduct](http://pdxruby.org/codeofconduct), der unter der selben Lizenz steht.
+Der Berlin Code of Conduct steht unter der [Creative Commons Attribution-ShareAlike 4.0 International (CC BY-SA 4.0)](https://creativecommons.org/licenses/by-sa/4.0/) Lizenz. Er basiert auf dem [pdx.rb code of conduct](http://pdxruby.org/codeofconduct).

--- a/source/localizable/_code-of-conduct.en.md
+++ b/source/localizable/_code-of-conduct.en.md
@@ -70,4 +70,4 @@ We expect all community participants (contributors, paid or otherwise; sponsors;
 License and attribution
 -----------------------
 
-Berlin Code of Conduct is distributed under a Creative Commons Attribution-ShareAlike license. It is based on the [pdx.rb code of conduct](http://pdxruby.org/codeofconduct), which is distributed under the same license.
+Berlin Code of Conduct is distributed under a [Creative Commons Attribution-ShareAlike 4.0 International (CC BY-SA 4.0)](https://creativecommons.org/licenses/by-sa/4.0/) license. It is based on the [pdx.rb code of conduct](http://pdxruby.org/codeofconduct).


### PR DESCRIPTION
This PR specifies the creative commons sharealike 4.0 international version for english and german. 