### PR TITLE
Use specified links to cc 4.0 international DE and EN

### DIFF
--- a/source/localizable/_code-of-conduct.de.md
+++ b/source/localizable/_code-of-conduct.de.md
@@ -70,4 +70,4 @@ Wir erwarten, dass sich alle Teilnehmenden der Community (bezahlte oder unbezahl
 Lizenz und Namensnennung
 ------------------------
 
-Der Berlin Code of Conduct steht unter der [Creative Commons Attribution-ShareAlike 4.0 International (CC BY-SA 4.0)](https://creativecommons.org/licenses/by-sa/4.0/) Lizenz. Er basiert auf dem [pdx.rb code of conduct](http://pdxruby.org/codeofconduct).
+Der Berlin Code of Conduct steht unter der [Creative Commons Attribution-ShareAlike 4.0 International (CC BY-SA 4.0)](https://creativecommons.org/licenses/by-sa/4.0/deed.de) Lizenz. Er basiert auf dem [pdx.rb code of conduct](http://pdxruby.org/codeofconduct).

--- a/source/localizable/_code-of-conduct.en.md
+++ b/source/localizable/_code-of-conduct.en.md
@@ -70,4 +70,4 @@ We expect all community participants (contributors, paid or otherwise; sponsors;
 License and attribution
 -----------------------
 
-Berlin Code of Conduct is distributed under a [Creative Commons Attribution-ShareAlike 4.0 International (CC BY-SA 4.0)](https://creativecommons.org/licenses/by-sa/4.0/) license. It is based on the [pdx.rb code of conduct](http://pdxruby.org/codeofconduct).
+Berlin Code of Conduct is distributed under a [Creative Commons Attribution-ShareAlike 4.0 International (CC BY-SA 4.0)](https://creativecommons.org/licenses/by-sa/4.0/deed.en) license. It is based on the [pdx.rb code of conduct](http://pdxruby.org/codeofconduct).


### PR DESCRIPTION
This PR links to the specified url for DE and EN of cc 4.0 international. 

Thanks for the hint, @lucaspinto ! :)