### PR TITLE
Add RubyUnconf Hamburg

### DIFF
--- a/data/supporters.json
+++ b/data/supporters.json
@@ -193,10 +193,34 @@
       "twitter": "hamburgsync",
       "contacts": [
         {
-          "name": "Kerstin Puschke",
-          "phone": "",
-          "email": "rug@kpuschke.eu"
+          "name": "Peter Schröder",
+          "phone": "+49 178 1391035",
+          "email": "ps@nofail.de"
         },
+        {
+          "name": "Jan Krutisch",
+          "phone": "+49 1752935345",
+          "email": "jan@krutisch.de"
+        },
+        {
+          "name": "Irina Lindt",
+           "phone": "+49 176 62761433",
+           "email": "lindtdev@gmail.com"
+        },
+        {
+          "name": "Jan Zaydowicz",
+           "phone": "+49 176 52857961",
+           "email": "jan.zaydowicz@gmail.com"
+        }
+      ]
+    },
+    {
+      "name": "Ruby Unconference Hamburg",
+      "city": "Hamburg",
+      "country": "Germany",
+      "link": "http://rubyunconf.eu/",
+      "twitter": "RubyUnConfHH",
+      "contacts": [
         {
           "name": "Peter Schröder",
           "phone": "+49 178 1391035",


### PR DESCRIPTION
This PR does two related things:

- It removes Kerstin from the list of the Ruby Usergroup supporters as she's not available anymore since she moved to Canada.
- It creates a new entry for the Ruby Unconference Hamburg which will happen on May 5./6.

Thanks!