### PR TITLE
Add the Malmö.rb user group as Supporters

### DIFF
--- a/data/supporters.json
+++ b/data/supporters.json
@@ -483,6 +483,20 @@
           "email": "fdmarcin@gmail.com"
         }
       ]
+    },
+    {
+      "name": "Malmö.rb",
+      "city": "Malmö",
+      "country": "Sweden",
+      "link": "http://malmorb.se",
+      "twitter": "malmorb",
+      "contacts": [
+        {
+          "name": "Olle Jonsson",
+          "email": "olle.jonsson@gmail.com",
+          "twitter": "olleolleolle"
+        }
+      ]
     }
   ],
   "conferences": [


### PR DESCRIPTION
This PR marks the Malmö Ruby Brigade - malmö.rb - as a **supporter** of the Berlin Code of Conduct.