### PR TITLE
Add WarsawJS

### DIFF
--- a/data/supporters.json
+++ b/data/supporters.json
@@ -1727,6 +1727,26 @@
           "email": "enusec@gmail.com"
         }
       ]
-    }
+    },
+    {
+      "name": "WarsawJS",
+      "city": "Warsaw",
+      "country": "Poland",
+      "link": "https://warsawjs.com",
+      "contacts": [
+        {
+          "name": "Piotr Zientara",
+          "twitter": "Piotr_Zientara",
+        },
+        {
+          "name": "Piotr Kowalski",
+          "twitter": "piecioshka",
+        },
+        {
+          "name": "Katarzyna Grabowska",
+          "twitter": "kasiarzyna25"
+        }
+      ]
+    },
   ]
 }


### PR DESCRIPTION
This PR marks the WarsawJS https://warsawjs.com as a supporter of the Berlin Code of Conduct.