### PR TITLE
Correct PDX CoC links

### DIFF
--- a/source/localizable/_code-of-conduct.de.md
+++ b/source/localizable/_code-of-conduct.de.md
@@ -70,4 +70,4 @@ Wir erwarten, dass sich alle Teilnehmenden der Community (bezahlte oder unbezahl
 Lizenz und Namensnennung
 ------------------------
 
-Der Berlin Code of Conduct steht unter der [Creative Commons Attribution-ShareAlike 4.0 International (CC BY-SA 4.0)](https://creativecommons.org/licenses/by-sa/4.0/) Lizenz. Er basiert auf dem [pdx.rb code of conduct](http://pdxruby.org/codeofconduct).
+Der Berlin Code of Conduct steht unter der [Creative Commons Attribution-ShareAlike 4.0 International (CC BY-SA 4.0)](https://creativecommons.org/licenses/by-sa/4.0/) Lizenz. Er basiert auf dem [pdx.rb Code of Conduct](https://pdxruby.org/CONDUCT).

--- a/source/localizable/_code-of-conduct.en.md
+++ b/source/localizable/_code-of-conduct.en.md
@@ -70,4 +70,4 @@ We expect all community participants (contributors, paid or otherwise; sponsors;
 License and attribution
 -----------------------
 
-Berlin Code of Conduct is distributed under a [Creative Commons Attribution-ShareAlike 4.0 International (CC BY-SA 4.0)](https://creativecommons.org/licenses/by-sa/4.0/) license. It is based on the [pdx.rb code of conduct](http://pdxruby.org/codeofconduct).
+Berlin Code of Conduct is distributed under a [Creative Commons Attribution-ShareAlike 4.0 International (CC BY-SA 4.0)](https://creativecommons.org/licenses/by-sa/4.0/) license. It is based on the [pdx.rb Code of Conduct](https://pdxruby.org/CONDUCT).

--- a/source/localizable/_code-of-conduct.es.md
+++ b/source/localizable/_code-of-conduct.es.md
@@ -68,4 +68,4 @@ Se espera que todos los participantes de la comunidad (colaboradores/as —pagos
 Licencia y atribución
 ---------------------
 
-El Berlin Code of Conduct se encuentra distribuido bajo una licencia [Creative Commons Attribution-ShareAlike 4.0 International (CC BY-SA 4.0)](https://creativecommons.org/licenses/by-sa/4.0/). Está basado en el [pdx.rb code of conduct](http://pdxruby.org/codeofconduct), que también es distribuido bajo la misma licencia.
+El Berlin Code of Conduct se encuentra distribuido bajo una licencia [Creative Commons Attribution-ShareAlike 4.0 International (CC BY-SA 4.0)](https://creativecommons.org/licenses/by-sa/4.0/). Está basado en el [pdx.rb Code of Conduct](https://pdxruby.org/CONDUCT), que también es distribuido bajo la misma licencia.

--- a/source/localizable/_code-of-conduct.fr.md
+++ b/source/localizable/_code-of-conduct.fr.md
@@ -65,5 +65,4 @@ Nous attendons de la part de tous les membres de la communauté (contributeurs p
 Licence et attribution
 -----
 
-Le Code de conduite de Berlin est distribué sous la licence [Creative Commons Attribution-ShareAlike 4.0 International (CC BY-SA 4.0)](https://creativecommons.org/licenses/by-sa/4.0/deed.fr)). Elle est basée sur le [code de conduite pdx.rb](http://pdxruby.org/codeofconduct).
-
+Le Code de conduite de Berlin est distribué sous la licence [Creative Commons Attribution-ShareAlike 4.0 International (CC BY-SA 4.0)](https://creativecommons.org/licenses/by-sa/4.0/deed.fr)). Elle est basée sur le [code de conduite pdx.rb](https://pdxruby.org/CONDUCT).

--- a/source/localizable/_code-of-conduct.it.md
+++ b/source/localizable/_code-of-conduct.it.md
@@ -69,5 +69,5 @@ Ci aspettiamo che tutti/e i/le partecipanti alla comunità (contributori/contrib
 Licenza e attribuzione
 -----------------------
 
-Berlin Code of Conduct è distribuito sotto licenza [Creative Commons Attribuzione - Condividi allo stesso modo 4.0 Internazionale (CC BY-SA 4.0)](https://creativecommons.org/licenses/by-sa/4.0/deed.it) e basato originariamente sul [pdx.rb code of conduct](http://pdxruby.org/codeofconduct).
+Berlin Code of Conduct è distribuito sotto licenza [Creative Commons Attribuzione - Condividi allo stesso modo 4.0 Internazionale (CC BY-SA 4.0)](https://creativecommons.org/licenses/by-sa/4.0/deed.it) e basato originariamente sul [pdx.rb Code of Conduct](https://pdxruby.org/CONDUCT).
 

--- a/source/localizable/_code-of-conduct.pl.md
+++ b/source/localizable/_code-of-conduct.pl.md
@@ -65,4 +65,4 @@ Oczekujemy, że wszyscy uczestnicy społeczności (organizatorzy, zarówno opła
 Licencja i uznanie autorstwa
 ----------------------------
 
-Berliński Kodeks Postępowania jest rozpowszechniany na warunkach licencji [Creative Commons Uznanie autorstwa-Na tych samych warunkach (CC BY-SA 4.0)](https://creativecommons.org/licenses/by-sa/4.0/deed.pl). Kodeks został stworzony na podstawie [pdx.rb code of conduct](http://pdxruby.org/codeofconduct).
+Berliński Kodeks Postępowania jest rozpowszechniany na warunkach licencji [Creative Commons Uznanie autorstwa-Na tych samych warunkach (CC BY-SA 4.0)](https://creativecommons.org/licenses/by-sa/4.0/deed.pl). Kodeks został stworzony na podstawie [pdx.rb Code of Conduct](https://pdxruby.org/CONDUCT).

--- a/source/localizable/_code-of-conduct.ru.md
+++ b/source/localizable/_code-of-conduct.ru.md
@@ -65,4 +65,4 @@
 Лицензия и авторство
 -----------------------
 
-Данный Кодекс Поведения распространяется под лицензией [Creative Commons Attribution-ShareAlike 4.0 International (CC BY-SA 4.0)](https://creativecommons.org/licenses/by-sa/4.0/). Он основан на [pdx.rb code of conduct](http://pdxruby.org/codeofconduct).
+Данный Кодекс Поведения распространяется под лицензией [Creative Commons Attribution-ShareAlike 4.0 International (CC BY-SA 4.0)](https://creativecommons.org/licenses/by-sa/4.0/). Он основан на [Портленд Кодекс Поведения](https://pdxruby.org/CONDUCT).

--- a/source/localizable/_code-of-conduct.ru.md
+++ b/source/localizable/_code-of-conduct.ru.md
@@ -65,4 +65,4 @@
 Лицензия и авторство
 -----------------------
 
-Данный Кодекс Поведения распространяется под лицензией [Creative Commons Attribution-ShareAlike 4.0 International (CC BY-SA 4.0)](https://creativecommons.org/licenses/by-sa/4.0/). Он основан на [Портленд Кодекс Поведения](https://pdxruby.org/CONDUCT).
+Данный Кодекс Поведения распространяется под лицензией [Creative Commons Attribution-ShareAlike 4.0 International (CC BY-SA 4.0)](https://creativecommons.org/licenses/by-sa/4.0/). Он основан на [Портлендский кодекс поведения](https://pdxruby.org/CONDUCT).


### PR DESCRIPTION
Similar to pull request #209 with the commit sha of 27c90f. I also updated russian specifically to say "Portland Code of Conduct", because it's the one language where PDX is most confusing. 

Using the gem `html-proofer` I checked if any other links were broken, excluding twitter/meetup and 301/0 exit status links. All looks good otherwise. If you want to investigate further, here was my script

```ruby
task :htmlproof do
  require "html-proofer"
  options = {
    :typhoeus => {
    :ssl_verifypeer => false,
    :ssl_verifyhost => 0
    },
    :url_ignore => [/twitter.com/, /meetup.com/],
    :http_status_ignore => [0, 301, 302]
  }
  HTMLProofer.check_directory("build", options).run
end
```