### PR TITLE
Add "Open South Code" event to data/supporters.json

### DIFF
--- a/data/supporters.json
+++ b/data/supporters.json
@@ -2389,6 +2389,20 @@
           "email": "hmgoldschmidt+lctfn@gmail.com"
         }
       ]
+    },
+    {
+      "name": "Open South Code",
+      "city": "Málaga",
+      "country": "Spain",
+      "link": "https://www.opensouthcode.org/",
+      "twitter": "opensouthcode",
+      "contacts": [
+        {
+          "name": "David Sedeño",
+          "twitter": "david_sedeno",
+          "email": "info@opensouthcode.org"
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
Hi, we are using the Berlin Code of Conduct for our event, and we will be appreciated it if you can add us to this list.