### PR TITLE
lernOS Community added to supporter list

### DIFF
--- a/data/supporters.json
+++ b/data/supporters.json
@@ -2389,6 +2389,18 @@
           "email": "hmgoldschmidt+lctfn@gmail.com"
         }
       ]
+    },
+    {
+      "name": "lernOS Community",
+      "city": "Nuremberg",
+      "country": "Germany",
+      "link": "https://lernos.org",
+      "contacts": [
+        {
+          "name": "Simon Dückert",
+          "email": "simon.dueckert@cogneon.de"
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
The lernOS communty with their yearly event lernOS Convention also supports the BCoC.